### PR TITLE
Improve UX for openshift-install

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,6 @@ oc get pods
 
 Use `latest-4.11` to automatically select the latest 4.11 nightly.
 
-`oc install` runs `openshift-install`:
-
-```shell
-oc install --dir /tmp/tmp.h0xN7tjsI9 create manifests
-```
-
 ### Reset this directory's setting
 
 ```shell

--- a/oc-setversion
+++ b/oc-setversion
@@ -117,8 +117,8 @@ else
 	print_info "config match: '$version'"
 
 	# Execute oc or openshift-install with the original arguments.
-	if [ "${1:-}" == 'install' ]; then
-		shift
+    binary=$(basename ${0})
+	if [ "${binary}" == 'openshift-install' ]; then
 		exec "${bin_dir}/openshift-install-linux-${version}" "$@"
 	else
 		exec "${bin_dir}/openshift-client-linux-${version}" "$@"


### PR DESCRIPTION
Instead of having to run `oc install [args]` we could just detect that
`openshift-install` is being executed (after putting the script in
`~/.local/bin/openshift-install` so the user will just run:

```
openshift-install setversion latest-4.11
openshift-install create cluster --dir .
```
